### PR TITLE
Add card model and attack mechanics

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,6 +1,7 @@
-from flask import Flask, render_template, jsonify
+from flask import Flask, render_template, jsonify, request
 from models.player import Player
-from game.logic import generate_orcs
+from game.logic import generate_orcs, player_attack
+from models.orc import Orc
 
 app = Flask(__name__)
 
@@ -18,6 +19,30 @@ def state():
         "player": player.to_dict(),
         "orcs": [orc.to_dict() for orc in orcs]
     })
+
+
+@app.route("/api/attack", methods=["POST"])
+def attack():
+    data = request.get_json()
+    card_name = data["card_name"]
+    orc_name = data["orc_name"]
+
+    card = next((c for c in player.deck if c.name == card_name), None)
+    orc = next((o for o in orcs if o.name == orc_name), None)
+
+    if card and orc:
+        result = player_attack(player, orc, card)
+        if result == "orc_defeated":
+            orcs.remove(orc)
+        return jsonify(
+            {
+                "result": result,
+                "player": player.to_dict(),
+                "orcs": [o.to_dict() for o in orcs],
+            }
+        )
+
+    return jsonify({"result": "error"}), 400
 
 if __name__ == "__main__":
     app.run(debug=True)

--- a/game/logic.py
+++ b/game/logic.py
@@ -1,4 +1,15 @@
 from models.orc import random_orc
 
+
 def generate_orcs():
     return [random_orc() for _ in range(3)]
+
+
+def player_attack(player, orc, card):
+    if player.mana >= card.mana_cost:
+        player.mana -= card.mana_cost
+        orc.life -= card.damage
+        if orc.life <= 0:
+            return "orc_defeated"
+        return "attack_successful"
+    return "not_enough_mana"

--- a/models/card.py
+++ b/models/card.py
@@ -1,0 +1,20 @@
+class Card:
+    def __init__(self, name, mana_cost, damage):
+        self.name = name
+        self.mana_cost = mana_cost
+        self.damage = damage
+
+    def to_dict(self):
+        return {
+            "name": self.name,
+            "mana_cost": self.mana_cost,
+            "damage": self.damage,
+        }
+
+
+def get_initial_deck():
+    return [
+        Card("Bola de Fogo", 3, 4),
+        Card("Raio Gélido", 2, 2),
+        Card("Mísseis Mágicos", 5, 6),
+    ]

--- a/models/player.py
+++ b/models/player.py
@@ -1,12 +1,15 @@
+from models.card import get_initial_deck
+
+
 class Player:
     def __init__(self, name):
         self.name = name
         self.mana = 10
-        self.deck = ["Bola de Fogo", "Raio Gélido", "Mísseis Mágicos"]
+        self.deck = get_initial_deck()
 
     def to_dict(self):
         return {
             "name": self.name,
             "mana": self.mana,
-            "deck": self.deck
+            "deck": [card.to_dict() for card in self.deck],
         }

--- a/static/main.js
+++ b/static/main.js
@@ -1,15 +1,71 @@
-window.onload = async () => {
+async function updateGameState() {
   const res = await fetch("/api/state");
   const data = await res.json();
+  renderGame(data);
+}
 
+function renderGame(data) {
   const div = document.getElementById("game-state");
   div.innerHTML = `
-    <h2>${data.player.name}</h2>
-    <p>Mana: ${data.player.mana}</p>
-    <p>Deck: ${data.player.deck.join(", ")}</p>
+    <div class="card mb-3">
+      <div class="card-body">
+        <h2 class="card-title">${data.player.name}</h2>
+        <p class="card-text">Mana: ${data.player.mana}</p>
+        <div class="d-flex">
+          ${data.player.deck
+            .map(
+              (card) => `
+            <div class="card mr-2" style="width: 10rem;">
+              <div class="card-body">
+                <h5 class="card-title">${card.name}</h5>
+                <p class="card-text">Custo: ${card.mana_cost}</p>
+                <p class="card-text">Dano: ${card.damage}</p>
+              </div>
+            </div>
+          `
+            )
+            .join("")}
+        </div>
+      </div>
+    </div>
+
     <h3>Orcs em campo:</h3>
-    <ul>
-      ${data.orcs.map(orc => `<li>${orc.name} - Vida: ${orc.life} - Pontos: ${orc.points}</li>`).join("")}
+    <ul class="list-group">
+      ${data.orcs
+        .map(
+          (orc) => `
+        <li class="list-group-item d-flex justify-content-between align-items-center">
+          ${orc.name} - Vida: ${orc.life} - Pontos: ${orc.points}
+          <div class="btn-group">
+            ${data.player.deck
+              .map(
+                (card) => `
+              <button class="btn btn-sm btn-danger" onclick="attack('${card.name}', '${orc.name}')">
+                Atacar com ${card.name}
+              </button>
+            `
+              )
+              .join("")}
+          </div>
+        </li>
+      `
+        )
+        .join("")}
     </ul>
   `;
-};
+}
+
+async function attack(cardName, orcName) {
+  const res = await fetch("/api/attack", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ card_name: cardName, orc_name: orcName }),
+  });
+  const data = await res.json();
+  if (data.result === "not_enough_mana") {
+    alert("Mana insuficiente!");
+  }
+  renderGame({ player: data.player, orcs: data.orcs });
+}
+
+window.onload = updateGameState;

--- a/templates/game.html
+++ b/templates/game.html
@@ -3,9 +3,10 @@
 <head>
   <meta charset="UTF-8">
   <title>Orcs Orcs Orcs Digital</title>
+  <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
   <script src="/static/main.js" defer></script>
 </head>
-<body>
+<body class="container mt-4">
   <h1>Orcs Orcs Orcs (versão web)</h1>
   <div id="game-state">
     <p>Carregando estado do jogo...</p>


### PR DESCRIPTION
## Summary
- add `Card` model and initial deck
- allow players to attack orcs via new API endpoint and mana/damage logic
- refresh frontend with card display and attack buttons

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688cfaf9b0ec8323950a937fcd0176d9