### PR TITLE
Add game-over and restart logic

### DIFF
--- a/app.py
+++ b/app.py
@@ -5,16 +5,31 @@ from models.orc import Orc
 
 app = Flask(__name__)
 
+
+def initial_state():
+    """Função para gerar o estado inicial do jogo."""
+    player = Player("Jogador 1")
+    return {
+        "player": player,
+        "orcs": generate_orcs(1),
+        "round": 1,
+        "score": 0,
+        "game_over": False,
+    }
+
+
 # --- Estado do Jogo ---
-player = Player("Jogador 1")
-orcs = generate_orcs(1)  # Começa com orcs da rodada 1
-game_state = {
-    "player": player,
-    "orcs": orcs,
-    "round": 1,
-    "score": 0,
-}
-# ----------------------
+game_state = initial_state()
+# --------------------
+
+
+def check_game_over(player, orcs):
+    """Verifica se o jogo terminou."""
+    if not orcs:
+        return False  # Não pode ser fim de jogo se não há orcs
+
+    min_mana_cost = min(card.mana_cost for card in player.deck)
+    return player.mana < min_mana_cost
 
 
 @app.route("/")
@@ -24,40 +39,44 @@ def game():
 
 @app.route("/api/state")
 def state():
-    # Usamos um dicionário separado para facilitar o envio como JSON
     return jsonify(
         {
             "player": game_state["player"].to_dict(),
             "orcs": [orc.to_dict() for orc in game_state["orcs"]],
             "round": game_state["round"],
             "score": game_state["score"],
+            "game_over": game_state["game_over"],
         }
     )
 
 
 @app.route("/api/attack", methods=["POST"])
 def attack():
+    if game_state["game_over"]:
+        return jsonify({"result": "game_over"}), 400
+
     data = request.get_json()
     card_name = data["card_name"]
     orc_name = data["orc_name"]
 
     card = next((c for c in game_state["player"].deck if c.name == card_name), None)
-    # Procuramos o orc pelo nome E pela vida, para diferenciar orcs com o mesmo nome
     orc = next((o for o in game_state["orcs"] if o.name == orc_name), None)
 
     if card and orc:
         result = player_attack(game_state["player"], orc, card)
 
         if result == "orc_defeated":
-            # Adiciona os pontos do orc à pontuação e o remove
             game_state["score"] += orc.points
             game_state["orcs"].remove(orc)
 
-            # Se não houver mais orcs, avance para a próxima rodada
             if not game_state["orcs"]:
                 game_state["round"] += 1
-                game_state["player"].mana = 10  # Restaura a mana do jogador
+                game_state["player"].mana = 10
                 game_state["orcs"] = generate_orcs(game_state["round"])
+
+        game_state["game_over"] = check_game_over(
+            game_state["player"], game_state["orcs"]
+        )
 
         return jsonify(
             {
@@ -66,10 +85,19 @@ def attack():
                 "orcs": [o.to_dict() for o in game_state["orcs"]],
                 "round": game_state["round"],
                 "score": game_state["score"],
+                "game_over": game_state["game_over"],
             }
         )
 
     return jsonify({"result": "error"}), 400
+
+
+@app.route("/api/restart", methods=["POST"])
+def restart():
+    """Rota para reiniciar o jogo."""
+    global game_state
+    game_state = initial_state()
+    return jsonify({"result": "restarted"})
 
 
 if __name__ == "__main__":

--- a/static/main.js
+++ b/static/main.js
@@ -6,6 +6,21 @@ async function updateGameState() {
 
 function renderGame(data) {
   const div = document.getElementById("game-state");
+
+  // Se o jogo terminou, mostra a tela de Fim de Jogo
+  if (data.game_over) {
+    div.innerHTML = `
+      <div class="text-center">
+        <h1>Fim de Jogo!</h1>
+        <h2>Pontuação Final: ${data.score}</h2>
+        <p>Você não tem mana suficiente para derrotar os orcs restantes.</p>
+        <button class="btn btn-primary btn-lg" onclick="restartGame()">Jogar Novamente</button>
+      </div>
+    `;
+    return;
+  }
+
+  // Caso contrário, renderiza o estado normal do jogo
   div.innerHTML = `
     <div class="d-flex justify-content-between mb-3">
       <h3>Rodada: ${data.round}</h3>
@@ -17,9 +32,7 @@ function renderGame(data) {
         <h2 class="card-title">${data.player.name}</h2>
         <p class="card-text font-weight-bold">Mana: ${data.player.mana}</p>
         <div class="d-flex">
-          ${data.player.deck
-            .map(
-              (card) => `
+          ${data.player.deck.map(card => `
             <div class="card mr-2" style="width: 10rem;">
               <div class="card-body">
                 <h5 class="card-title">${card.name}</h5>
@@ -27,38 +40,28 @@ function renderGame(data) {
                 <p class="card-text">Dano: ${card.damage}</p>
               </div>
             </div>
-          `
-            )
-            .join("")}
+          `).join("")}
         </div>
       </div>
     </div>
 
     <h3>Orcs em campo:</h3>
     <ul class="list-group">
-      ${data.orcs
-        .map(
-          (orc) => `
+      ${data.orcs.map(orc => `
         <li class="list-group-item d-flex justify-content-between align-items-center">
           <div>
             <strong>${orc.name}</strong><br>
             Vida: ${orc.life} | Pontos: ${orc.points}
           </div>
           <div class="btn-group">
-            ${data.player.deck
-              .map(
-                (card) => `
+            ${data.player.deck.map(card => `
               <button class="btn btn-sm btn-danger ml-1" onclick="attack('${card.name}', '${orc.name}')" ${data.player.mana < card.mana_cost ? 'disabled' : ''}>
                 Atacar com ${card.name}
               </button>
-            `
-              )
-              .join("")}
+            `).join("")}
           </div>
         </li>
-      `
-        )
-        .join("")}
+      `).join("")}
     </ul>
   `;
 }
@@ -73,8 +76,12 @@ async function attack(cardName, orcName) {
   if (data.result === "not_enough_mana") {
       alert("Mana insuficiente!");
   }
-  // Re-renderiza o jogo com o novo estado que vem da API
   renderGame(data);
+}
+
+async function restartGame() {
+  await fetch("/api/restart", { method: 'POST' });
+  await updateGameState();
 }
 
 window.onload = updateGameState;


### PR DESCRIPTION
## Summary
- End the game when mana is insufficient to play any card against remaining orcs
- Add `/api/restart` endpoint and front-end button to reset state
- Show a game-over screen with final score and restart option

## Testing
- `python -m py_compile app.py game/logic.py models/player.py models/orc.py models/card.py`
- `node --check static/main.js`


------
https://chatgpt.com/codex/tasks/task_e_688d0a2cd0b88323bc5121e3e45e19b8