### PR TITLE
Implement map-based orc movement with end-turn mechanic

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,35 +1,30 @@
 from flask import Flask, render_template, jsonify, request
 from models.player import Player
-from game.logic import generate_orcs, player_attack
-from models.orc import Orc
+from game.logic import player_attack, advance_orcs
+from models.orc import random_orc
+import random
 
 app = Flask(__name__)
 
 
 def initial_state():
-    """Função para gerar o estado inicial do jogo."""
+    """Função para gerar o estado inicial do jogo com o mapa."""
     player = Player("Jogador 1")
+    game_map = {str(i): [[], [], []] for i in range(1, 7)}
+    game_map["1"][0].append(random_orc(1))
     return {
         "player": player,
-        "orcs": generate_orcs(1),
+        "map": game_map,
         "round": 1,
         "score": 0,
         "game_over": False,
+        "log": ["O jogo começou! Um orc apareceu na região 1."],
     }
 
 
 # --- Estado do Jogo ---
 game_state = initial_state()
 # --------------------
-
-
-def check_game_over(player, orcs):
-    """Verifica se o jogo terminou."""
-    if not orcs:
-        return False  # Não pode ser fim de jogo se não há orcs
-
-    min_mana_cost = min(card.mana_cost for card in player.deck)
-    return player.mana < min_mana_cost
 
 
 @app.route("/")
@@ -39,13 +34,18 @@ def game():
 
 @app.route("/api/state")
 def state():
+    serialized_map = {
+        lane: [[o.to_dict() for o in area] for area in areas]
+        for lane, areas in game_state["map"].items()
+    }
     return jsonify(
         {
             "player": game_state["player"].to_dict(),
-            "orcs": [orc.to_dict() for orc in game_state["orcs"]],
+            "map": serialized_map,
             "round": game_state["round"],
             "score": game_state["score"],
             "game_over": game_state["game_over"],
+            "log": game_state["log"],
         }
     )
 
@@ -57,39 +57,74 @@ def attack():
 
     data = request.get_json()
     card_name = data["card_name"]
-    orc_name = data["orc_name"]
+    orc_id = data["orc_id"]
+    lane = data["lane"]
+    area = data["area"]
 
     card = next((c for c in game_state["player"].deck if c.name == card_name), None)
-    orc = next((o for o in game_state["orcs"] if o.name == orc_name), None)
+    orc_list = game_state["map"][lane][area]
+    orc = next((o for o in orc_list if o.id == orc_id), None)
 
     if card and orc:
         result = player_attack(game_state["player"], orc, card)
-
         if result == "orc_defeated":
             game_state["score"] += orc.points
-            game_state["orcs"].remove(orc)
+            orc_list.remove(orc)
 
-            if not game_state["orcs"]:
-                game_state["round"] += 1
-                game_state["player"].mana = 10
-                game_state["orcs"] = generate_orcs(game_state["round"])
-
-        game_state["game_over"] = check_game_over(
-            game_state["player"], game_state["orcs"]
-        )
-
+        serialized_map = {
+            lane_num: [[o.to_dict() for o in area_list] for area_list in areas]
+            for lane_num, areas in game_state["map"].items()
+        }
         return jsonify(
             {
                 "result": result,
                 "player": game_state["player"].to_dict(),
-                "orcs": [o.to_dict() for o in game_state["orcs"]],
+                "map": serialized_map,
                 "round": game_state["round"],
                 "score": game_state["score"],
                 "game_over": game_state["game_over"],
+                "log": game_state["log"],
             }
         )
 
     return jsonify({"result": "error"}), 400
+
+
+@app.route("/api/end_turn", methods=["POST"])
+def end_turn():
+    if game_state["game_over"]:
+        return jsonify({"result": "game_over"}), 400
+
+    orcs_at_gate = advance_orcs(game_state["map"])
+    if orcs_at_gate:
+        game_state["log"].append(
+            f"{len(orcs_at_gate)} orcs chegaram à torre! Fim de jogo!"
+        )
+        game_state["game_over"] = True
+
+    game_state["round"] += 1
+    lane_to_spawn = str(random.randint(1, 6))
+    new_orc = random_orc(game_state["round"])
+    game_state["map"][lane_to_spawn][0].append(new_orc)
+    game_state["log"].append(
+        f"Um novo {new_orc.name} apareceu na região {lane_to_spawn}."
+    )
+    game_state["player"].mana = 10
+
+    serialized_map = {
+        lane: [[o.to_dict() for o in area] for area in areas]
+        for lane, areas in game_state["map"].items()
+    }
+    return jsonify(
+        {
+            "player": game_state["player"].to_dict(),
+            "map": serialized_map,
+            "round": game_state["round"],
+            "score": game_state["score"],
+            "game_over": game_state["game_over"],
+            "log": game_state["log"],
+        }
+    )
 
 
 @app.route("/api/restart", methods=["POST"])

--- a/game/logic.py
+++ b/game/logic.py
@@ -1,10 +1,4 @@
-from models.orc import random_orc
 
-
-def generate_orcs(round_number):
-    """Gera uma lista de orcs para a rodada informada."""
-    # A cada rodada, os orcs terão mais vida e darão mais pontos
-    return [random_orc(round_number) for _ in range(3)]
 
 
 def player_attack(player, orc, card):
@@ -15,3 +9,19 @@ def player_attack(player, orc, card):
             return "orc_defeated"
         return "attack_successful"
     return "not_enough_mana"
+
+
+def advance_orcs(game_map):
+    """Move todos os orcs no mapa uma posição para a frente."""
+    orcs_at_gate = []
+    for lane in game_map.values():
+        if lane[2]:
+            orcs_at_gate.extend(lane[2])
+            lane[2] = []
+        if lane[1]:
+            lane[2].extend(lane[1])
+            lane[1] = []
+        if lane[0]:
+            lane[1].extend(lane[0])
+            lane[0] = []
+    return orcs_at_gate

--- a/models/orc.py
+++ b/models/orc.py
@@ -1,14 +1,17 @@
 import random
+import uuid
 
 
 class Orc:
     def __init__(self, name, life, points):
+        self.id = str(uuid.uuid4())
         self.name = name
         self.life = life
         self.points = points
 
     def to_dict(self):
         return {
+            "id": self.id,
             "name": self.name,
             "life": self.life,
             "points": self.points,


### PR DESCRIPTION
## Summary
- Assign unique IDs to each orc and expose them to the frontend
- Add map and end-turn routes so orcs advance toward the tower and trigger game over on arrival
- Render six-lane map and attack controls on the frontend

## Testing
- `python -m py_compile models/orc.py game/logic.py app.py`
- `node --check static/main.js`


------
https://chatgpt.com/codex/tasks/task_e_688d0c5e85048323869555fa512f4793