### PR TITLE
Refactor game page layout

### DIFF
--- a/static/main.js
+++ b/static/main.js
@@ -5,68 +5,60 @@ async function updateGameState() {
 }
 
 function renderGame(data) {
-  const div = document.getElementById("game-state");
-
+  // Se o jogo terminou, mostra a tela de Fim de Jogo (lógica pode ser melhorada)
   if (data.game_over) {
-    div.innerHTML = `
-      <div class="text-center">
+    document.getElementById('game-container').innerHTML = `
+      <div style="background-color: rgba(0,0,0,0.8); text-align: center; padding: 50px;">
         <h1>Fim de Jogo!</h1>
         <h2>Pontuação Final: ${data.score}</h2>
-        <p>${data.log[data.log.length - 1] || ''}</p>
-        <button class="btn btn-primary btn-lg" onclick="restartGame()">Jogar Novamente</button>
+        <button onclick="restartGame()">Jogar Novamente</button>
       </div>
     `;
     return;
   }
 
-  let mapHtml = '<div class="row">';
+  // Renderiza a barra superior
+  document.getElementById('round-info').innerText = `Rodada: ${data.round}`;
+  document.getElementById('score-info').innerText = `Pontuação: ${data.score}`;
+
+  // Renderiza o mapa
+  const mapArea = document.getElementById('map-area');
+  let mapHtml = '';
   for (let lane = 1; lane <= 6; lane++) {
-    mapHtml += `<div class="col-md-4 border p-2"><h4>Região ${lane}</h4>`;
-    const areaNames = ['Externa', 'Meio', 'Interna'];
-    for (let area = 0; area < 3; area++) {
-      mapHtml += `<div><strong>${areaNames[area]}:</strong>`;
-      data.map[lane][area].forEach(orc => {
-        mapHtml += `<div class="d-flex justify-content-between align-items-center">`;
-        mapHtml += `<span>${orc.name} (Vida: ${orc.life})</span>`;
-        mapHtml += `<div>`;
-        data.player.deck.forEach(card => {
-          mapHtml += `<button class="btn btn-sm btn-danger ml-1" onclick="attack('${card.name}','${orc.id}',${lane},${area})" ${data.player.mana < card.mana_cost ? 'disabled' : ''}>${card.name}</button>`;
+    mapHtml += `<div class="region-lane"><h4>Região ${lane}</h4>`;
+    ['Externa', 'Meio', 'Interna'].forEach((areaName, areaIndex) => {
+        mapHtml += `<div><strong>${areaName}:</strong>`;
+        data.map[lane][areaIndex].forEach(orc => {
+            mapHtml += `<div class="orc-item">${orc.name} (Vida: ${orc.life})</div>`;
         });
-        mapHtml += `</div></div>`;
-      });
-      mapHtml += `</div>`;
-    }
-    mapHtml += `</div>`;
+        mapHtml += `</div>`;
+    });
+    mapHtml += '</div>';
   }
-  mapHtml += `</div><button class="btn btn-primary mt-3" onclick="endTurn()">Terminar Turno</button>`;
+  mapArea.innerHTML = mapHtml;
 
-  div.innerHTML = `
-    <div class="d-flex justify-content-between mb-3">
-      <h3>Rodada: ${data.round}</h3>
-      <h3>Pontuação: ${data.score}</h3>
-    </div>
+  // Renderiza a área do jogador
+  document.getElementById('player-stats').innerHTML = `
+    <h2>${data.player.name}</h2>
+    <p>Mana: ${data.player.mana}</p>
+  `;
 
-    <div class="card mb-3">
-      <div class="card-body">
-        <h2 class="card-title">${data.player.name}</h2>
-        <p class="card-text font-weight-bold">Mana: ${data.player.mana}</p>
-        <div class="d-flex">
-          ${data.player.deck.map(card => `
-            <div class="card mr-2" style="width: 10rem;">
-              <div class="card-body">
-                <h5 class="card-title">${card.name}</h5>
-                <p class="card-text">Custo: ${card.mana_cost}</p>
-                <p class="card-text">Dano: ${card.damage}</p>
-              </div>
-            </div>
-          `).join("")}
-        </div>
+  const playerHand = document.getElementById('player-hand');
+  playerHand.innerHTML = data.player.deck.map(card => `
+    <div class="card-item">
+      <h5>${card.name}</h5>
+      <p>Custo: ${card.mana_cost}</p>
+      <p>Dano: ${card.damage}</p>
       </div>
-    </div>
-    ${mapHtml}
+  `).join('');
+
+  // Renderiza o botão de terminar turno
+  document.getElementById('end-turn-container').innerHTML = `
+    <button onclick="endTurn()">Terminar Turno</button>
   `;
 }
 
+// Função de ataque permanece, mas os botões precisam ser adicionados ao mapa futuramente
 async function attack(cardName, orcId, lane, area) {
   const res = await fetch("/api/attack", {
     method: 'POST',

--- a/static/style.css
+++ b/static/style.css
@@ -1,0 +1,84 @@
+body {
+    margin: 0;
+    font-family: sans-serif;
+    color: white; /* Define a cor do texto padrão como branco */
+}
+
+#game-container {
+    display: flex;
+    flex-direction: column;
+    height: 100vh; /* Ocupa a altura total da tela */
+    background-image: url('http://googleusercontent.com/file_content/1'); /* SUA IMAGEM DO MAPA */
+    background-size: cover;
+    background-position: center;
+}
+
+#top-bar {
+    display: flex;
+    justify-content: space-between;
+    padding: 10px 20px;
+    background-color: rgba(0, 0, 0, 0.5); /* Fundo preto semi-transparente */
+    font-size: 1.2em;
+}
+
+#map-area {
+    flex-grow: 1; /* Faz esta área ocupar o espaço restante */
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 10px;
+    padding: 20px;
+}
+
+.region-lane {
+    background-color: rgba(0, 0, 0, 0.6);
+    border: 1px solid #8B4513; /* Cor de madeira escura */
+    border-radius: 8px;
+    padding: 10px;
+}
+
+.orc-item {
+    background-color: rgba(139, 0, 0, 0.7); /* Vermelho escuro */
+    padding: 5px;
+    margin-top: 5px;
+    border-radius: 4px;
+}
+
+#player-area {
+    background-color: rgba(0, 0, 0, 0.7);
+    padding: 10px;
+}
+
+#player-stats {
+    text-align: center;
+    font-size: 1.5em;
+    margin-bottom: 10px;
+}
+
+#player-hand {
+    display: flex;
+    justify-content: center;
+    gap: 10px;
+}
+
+.card-item {
+    background-color: #DEB887; /* Cor de pergaminho */
+    color: #3a2a1a; /* Texto escuro */
+    border: 3px solid #8B4513;
+    border-radius: 10px;
+    width: 120px;
+    padding: 10px;
+    box-shadow: 3px 3px 5px rgba(0,0,0,0.5);
+    text-align: center;
+}
+
+#end-turn-container {
+    text-align: center;
+    padding: 10px;
+    background-color: rgba(0, 0, 0, 0.5);
+}
+
+#end-turn-container button {
+    padding: 10px 20px;
+    font-size: 1.2em;
+    cursor: pointer;
+}

--- a/templates/game.html
+++ b/templates/game.html
@@ -3,13 +3,29 @@
 <head>
   <meta charset="UTF-8">
   <title>Orcs Orcs Orcs Digital</title>
-  <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
+  <link rel="stylesheet" href="/static/style.css">
   <script src="/static/main.js" defer></script>
 </head>
-<body class="container mt-4">
-  <h1>Orcs Orcs Orcs (versão web)</h1>
-  <div id="game-state">
-    <p>Carregando estado do jogo...</p>
+<body>
+  <div id="game-container">
+    
+    <div id="top-bar">
+      <div id="round-info"></div>
+      <div id="score-info"></div>
+    </div>
+
+    <div id="map-area">
+      </div>
+
+    <div id="player-area">
+      <div id="player-stats"></div>
+      <div id="player-hand">
+        </div>
+    </div>
+
+    <div id="end-turn-container">
+        </div>
+
   </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add board-themed stylesheet for layout, map grid and player areas
- restructure game.html into map, player and control sections
- rewrite main.js rendering to populate new containers and show game-over screen

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_6890bc6abc448323ad624fa98c5c8485